### PR TITLE
Bugfix/match times

### DIFF
--- a/src/main/java/com/smalltalk/SmallTalkFootball/domain/Fixture.java
+++ b/src/main/java/com/smalltalk/SmallTalkFootball/domain/Fixture.java
@@ -9,7 +9,7 @@ import lombok.NoArgsConstructor;
 import org.springframework.data.annotation.Id;
 import org.springframework.data.mongodb.core.mapping.Document;
 
-import java.time.LocalDateTime;
+import java.time.Instant;
 import java.util.*;
 
 @Builder
@@ -38,7 +38,7 @@ public class Fixture {
 
     private int externalId;
 
-    private LocalDateTime matchDateTime;
+    private Instant matchDateTime;
 
     private boolean finished;
 

--- a/src/main/java/com/smalltalk/SmallTalkFootball/repositories/FixtureRepository.java
+++ b/src/main/java/com/smalltalk/SmallTalkFootball/repositories/FixtureRepository.java
@@ -4,7 +4,6 @@ import com.smalltalk.SmallTalkFootball.domain.Fixture;
 import org.springframework.data.mongodb.repository.MongoRepository;
 
 import java.time.Instant;
-import java.time.LocalDateTime;
 import java.util.List;
 
 public interface FixtureRepository extends MongoRepository<Fixture, String> {

--- a/src/main/java/com/smalltalk/SmallTalkFootball/repositories/FixtureRepository.java
+++ b/src/main/java/com/smalltalk/SmallTalkFootball/repositories/FixtureRepository.java
@@ -3,13 +3,14 @@ package com.smalltalk.SmallTalkFootball.repositories;
 import com.smalltalk.SmallTalkFootball.domain.Fixture;
 import org.springframework.data.mongodb.repository.MongoRepository;
 
+import java.time.Instant;
 import java.time.LocalDateTime;
 import java.util.List;
 
 public interface FixtureRepository extends MongoRepository<Fixture, String> {
 
-    long deleteByMatchDateTimeBefore(LocalDateTime earliestMatchDay);
+    long deleteByMatchDateTimeBefore(Instant earliestMatchDay);
 
-    List<Fixture> findByMatchDateTimeAfter(LocalDateTime earliestMatchDay);
+    List<Fixture> findByMatchDateTimeAfter(Instant earliestMatchDay);
 
 }

--- a/src/main/java/com/smalltalk/SmallTalkFootball/services/FixtureService.java
+++ b/src/main/java/com/smalltalk/SmallTalkFootball/services/FixtureService.java
@@ -12,7 +12,9 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.time.Instant;
 import java.time.LocalDate;
+import java.time.ZoneOffset;
 import java.util.*;
 import java.util.stream.Collectors;
 
@@ -64,7 +66,8 @@ public class FixtureService {
     }
 
     private void deleteOldFixtures(LocalDate deleteMatchesDate) {
-        long deletedFixtures = repo.deleteByMatchDateTimeBefore(deleteMatchesDate.atStartOfDay());
+        Instant startOfDay = deleteMatchesDate.atStartOfDay(ZoneOffset.UTC).toInstant();
+        long deletedFixtures = repo.deleteByMatchDateTimeBefore(startOfDay);
         log.info("Deleted {} fixtures", deletedFixtures);
     }
 
@@ -77,7 +80,8 @@ public class FixtureService {
     }
 
     private Set<Integer> getFixturesExternalIds(LocalDate earliestMatchDay) {
-        return repo.findByMatchDateTimeAfter(earliestMatchDay.atStartOfDay()).stream()
+        Instant startOfDay = earliestMatchDay.atStartOfDay(ZoneOffset.UTC).toInstant();
+        return repo.findByMatchDateTimeAfter(startOfDay).stream()
                 .map(Fixture::getExternalId)
                 .collect(Collectors.toSet());
     }

--- a/src/main/java/com/smalltalk/SmallTalkFootball/services/FootballApiService.java
+++ b/src/main/java/com/smalltalk/SmallTalkFootball/services/FootballApiService.java
@@ -83,6 +83,7 @@ public class FootballApiService {
                                 .queryParam("from", fromDate.format(DateTimeFormatter.ISO_LOCAL_DATE))
                                 .queryParam("to", LocalDate.now().format(DateTimeFormatter.ISO_LOCAL_DATE))
                                 .queryParam("league_id", competition.getCode())
+                                .queryParam("timezone", "UTC")
                                 .build())
                         .retrieve()
                         .toEntity(String.class),

--- a/src/main/java/com/smalltalk/SmallTalkFootball/system/utils/mappers/FixtureMapper.java
+++ b/src/main/java/com/smalltalk/SmallTalkFootball/system/utils/mappers/FixtureMapper.java
@@ -12,9 +12,7 @@ import com.smalltalk.SmallTalkFootball.models.dto.GoalscorerItem;
 import com.smalltalk.SmallTalkFootball.models.dto.MatchDto;
 import com.smalltalk.SmallTalkFootball.models.dto.StatisticDto;
 
-import java.time.LocalDate;
-import java.time.LocalDateTime;
-import java.time.LocalTime;
+import java.time.*;
 import java.util.List;
 import java.util.Objects;
 
@@ -83,11 +81,12 @@ public class FixtureMapper {
         }
     }
 
-    private static LocalDateTime mapTime(MatchDto matchDto) {
+    private static Instant mapTime(MatchDto matchDto) {
         LocalDate date = LocalDate.parse(matchDto.getMatchDate());
         LocalTime time = LocalTime.parse(matchDto.getMatchTime());
 
-        return LocalDateTime.of(date, time);
+        LocalDateTime localDateTime = LocalDateTime.of(date, time);
+        return localDateTime.toInstant(ZoneOffset.UTC);
     }
 
     private static List<Goal> mapGoals(MatchDto matchDto) {


### PR DESCRIPTION
Fix bug where match times displayed on the front end where not correct. The times fetched and stored in the DB where in Berlin TZ and regarded as UTC. Also, changing to Instant from LocalDateTime allowed adding time offset.